### PR TITLE
Refactor cryptographic function calls in WASM wrappers to use mlkem f…

### DIFF
--- a/wasm/wasm_wrapper_1024.c
+++ b/wasm/wasm_wrapper_1024.c
@@ -9,15 +9,15 @@
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem1024_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
-    return crypto_kem_keypair_derand(pk, sk, coins);
+    return mlkem_keypair_derand(pk, sk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem1024_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins) {
-    return crypto_kem_enc_derand(ct, ss, pk, coins);
+    return mlkem_enc_derand(ct, ss, pk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem1024_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
-    return crypto_kem_dec(ss, ct, sk);
+    return mlkem_dec(ss, ct, sk);
 }

--- a/wasm/wasm_wrapper_512.c
+++ b/wasm/wasm_wrapper_512.c
@@ -9,15 +9,15 @@
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem512_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
-    return crypto_kem_keypair_derand(pk, sk, coins);
+    return mlkem_keypair_derand(pk, sk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem512_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins) {
-    return crypto_kem_enc_derand(ct, ss, pk, coins);
+    return mlkem_enc_derand(ct, ss, pk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem512_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
-    return crypto_kem_dec(ss, ct, sk);
+    return mlkem_dec(ss, ct, sk);
 }

--- a/wasm/wasm_wrapper_768.c
+++ b/wasm/wasm_wrapper_768.c
@@ -9,15 +9,15 @@
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem768_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
-    return crypto_kem_keypair_derand(pk, sk, coins);
+    return mlkem_keypair_derand(pk, sk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem768_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins) {
-    return crypto_kem_enc_derand(ct, ss, pk, coins);
+    return mlkem_enc_derand(ct, ss, pk, coins);
 }
 
 EMSCRIPTEN_KEEPALIVE
 int mlkem768_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
-    return crypto_kem_dec(ss, ct, sk);
+    return mlkem_dec(ss, ct, sk);
 }


### PR DESCRIPTION
…unctions

- Updated keypair, encryption, and decryption functions in wasm_wrapper_512.c, wasm_wrapper_768.c, and wasm_wrapper_1024.c to call mlkem_* functions instead of crypto_kem_* functions for consistency and improved clarity.