### PR TITLE
Refactor TypeScript types for improved clarity and consistency

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "error"
+			}
 		}
 	},
 	"assist": {
@@ -32,17 +35,5 @@
 				"organizeImports": "on"
 			}
 		}
-	},
-	"overrides": [
-		{
-			"includes": ["src/types.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noExplicitAny": "off"
-					}
-				}
-			}
-		}
-	]
+	}
 }

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -43,6 +43,13 @@ const typeOnlyExports = [
 	"SqisignWebGpuSupport",
 	"SqisignWebGpuVariant",
 	"SqisignBenchSteps",
+	"BytesLike",
+	"IFnDsa",
+	"IMlKem",
+	"KeyPair",
+	"MlKemKeyPair",
+	"EncryptResult",
+	"SecretLike",
 ];
 
 const errors = [];

--- a/src/fndsa.ts
+++ b/src/fndsa.ts
@@ -7,50 +7,13 @@ import {
 	withStack,
 	writeBytes,
 } from "./signature-common.js";
-import type { FnDsaVariant, IFnDsa, KeyPair } from "./types.js";
+import type { BytesLike, FnDsaVariant, IFnDsa, KeyPair } from "./types.js";
+import type { Falcon512Wasm } from "./vendor/falcon512.js";
 import Falcon512Module from "./vendor/falcon512.js";
+import type { Falcon1024Wasm } from "./vendor/falcon1024.js";
 import Falcon1024Module from "./vendor/falcon1024.js";
 
-type FalconModule = {
-	_falcon512_public_key_bytes?: () => number;
-	_falcon512_private_key_bytes?: () => number;
-	_falcon512_signature_bytes?: () => number;
-	_falcon512_seed_bytes?: () => number;
-	_falcon512_keypair_seeded?: (pk: number, sk: number, seed: number) => number;
-	_falcon512_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_falcon512_verify?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-	_falcon1024_public_key_bytes?: () => number;
-	_falcon1024_private_key_bytes?: () => number;
-	_falcon1024_signature_bytes?: () => number;
-	_falcon1024_seed_bytes?: () => number;
-	_falcon1024_keypair_seeded?: (pk: number, sk: number, seed: number) => number;
-	_falcon1024_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_falcon1024_verify?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-} & import("./signature-common.js").EmscriptenModule;
+type FalconModule = Falcon512Wasm & Falcon1024Wasm;
 
 type FalconApi = {
 	getModule: () => Promise<FalconModule>;
@@ -200,17 +163,14 @@ class FnDsaWrapper implements IFnDsa {
 		};
 	}
 
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array> {
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array> {
 		return Promise.all([
 			ensureInit(this.variant),
 			Promise.resolve(private_key),
 		]).then(([module, sk]) => {
 			const api = getApi(this.variant);
-			const msg = asBytes(message as Uint8Array | ArrayBuffer | string);
-			const key = asBytes(sk as Uint8Array | ArrayBuffer | string);
+			const msg = asBytes(message);
+			const key = asBytes(sk);
 			const seed = crypto.getRandomValues(
 				new Uint8Array(api.seedBytes(module)),
 			);
@@ -229,9 +189,9 @@ class FnDsaWrapper implements IFnDsa {
 	}
 
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean> {
 		return Promise.all([
 			ensureInit(this.variant),
@@ -240,7 +200,7 @@ class FnDsaWrapper implements IFnDsa {
 			const api = getApi(this.variant);
 			const sig = asBytes(signature);
 			const msg = asBytes(message);
-			const key = asBytes(pk as Uint8Array | ArrayBuffer | string);
+			const key = asBytes(pk);
 			return withStack(module, (alloc) => {
 				const sigPtr = writeBytes(module, alloc, sig);
 				const msgPtr = writeBytes(module, alloc, msg);
@@ -253,7 +213,7 @@ class FnDsaWrapper implements IFnDsa {
 		});
 	}
 
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string {
+	buffer_to_string(value: BytesLike): string {
 		if (typeof value === "string") return value;
 		return toHex(asBytes(value));
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import type { EncryptResult, IMlKem, KeyPair, MaybePromise } from "./types.js";
+import type {
+	EncryptResult,
+	IMlKem,
+	MaybePromise,
+	MlKemKeyPair,
+	SecretLike,
+} from "./types.js";
 import mlkem768 from "./vendor/mlkem.js";
 import mlkem512 from "./vendor/mlkem512.js";
 import mlkem1024 from "./vendor/mlkem1024.js";
@@ -82,6 +88,18 @@ export {
 	setSqisignAccelWorkerUrl,
 } from "./sqisign-webgpu.js";
 
+export type {
+	BytesLike,
+	EncryptResult,
+	IFnDsa,
+	IMlDsa,
+	IMlKem,
+	KeyPair,
+	MaybePromise,
+	MlKemKeyPair,
+	SecretLike,
+} from "./types.js";
+
 /** Minimal surface used by this package (mlkem-wasm–style API). */
 type MlKemImpl = {
 	generateKey(
@@ -163,7 +181,9 @@ function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 	return bytes.buffer as ArrayBuffer;
 }
 
-async function secretToKeyBytes(secret: unknown): Promise<Uint8Array> {
+async function secretToKeyBytes(
+	secret: MaybePromise<SecretLike>,
+): Promise<Uint8Array> {
 	const resolved = await secret;
 
 	if (typeof resolved === "string") return hexStringToBytes(resolved);
@@ -186,7 +206,7 @@ class MlKemWrapper implements IMlKem {
 		private readonly algorithm: { readonly name: string },
 	) {}
 
-	keypair(): KeyPair {
+	keypair(): MlKemKeyPair {
 		const keyPairPromise = this.impl.generateKey(this.algorithm, true, [
 			"encapsulateBits",
 			"decapsulateBits",
@@ -200,10 +220,9 @@ class MlKemWrapper implements IMlKem {
 		};
 	}
 
-	encrypt(public_key: unknown): EncryptResult {
-		const publicKeyPromise = Promise.resolve(public_key);
-		const encPromise = publicKeyPromise.then((pk) =>
-			this.impl.encapsulateBits(this.algorithm, pk as CryptoKey),
+	encrypt(public_key: MaybePromise<CryptoKey>): EncryptResult {
+		const encPromise = Promise.resolve(public_key).then((pk) =>
+			this.impl.encapsulateBits(this.algorithm, pk),
 		);
 
 		return {
@@ -215,32 +234,41 @@ class MlKemWrapper implements IMlKem {
 		};
 	}
 
-	decrypt(cyphertext: unknown, private_key: unknown): Promise<unknown> {
-		const ctPromise = Promise.resolve(cyphertext);
-		const skPromise = Promise.resolve(private_key);
-
-		return Promise.all([ctPromise, skPromise]).then(([ct, sk]) =>
-			this.impl.decapsulateBits(
-				this.algorithm,
-				sk as CryptoKey,
-				ct as BufferSource,
-			),
-		);
+	decrypt(
+		cyphertext: MaybePromise<BufferSource>,
+		private_key: MaybePromise<CryptoKey>,
+	): Promise<ArrayBuffer> {
+		return Promise.all([
+			Promise.resolve(cyphertext),
+			Promise.resolve(private_key),
+		]).then(([ct, sk]) => this.impl.decapsulateBits(this.algorithm, sk, ct));
 	}
 
-	buffer_to_string(buffer: unknown): MaybePromise<string> {
+	buffer_to_string(
+		buffer: MaybePromise<CryptoKey | BufferSource | string>,
+	): MaybePromise<string> {
 		if (buffer && typeof (buffer as Promise<unknown>).then === "function") {
-			return (buffer as Promise<unknown>).then((b) => this.buffer_to_string(b));
+			return (buffer as Promise<CryptoKey | BufferSource | string>).then((b) =>
+				this.buffer_to_string(b),
+			);
 		}
 
-		if (buffer instanceof CryptoKey) {
-			return cryptoKeyToRawHex(this.impl, buffer);
+		const value = buffer as CryptoKey | BufferSource | string;
+		if (value instanceof CryptoKey) {
+			return cryptoKeyToRawHex(this.impl, value);
 		}
 
-		return bytesToHexWithSpaces(bufferSourceToBytes(buffer));
+		if (typeof value === "string") {
+			return value;
+		}
+
+		return bytesToHexWithSpaces(bufferSourceToBytes(value));
 	}
 
-	async encryptMessage(message: string, secret: unknown): Promise<Uint8Array> {
+	async encryptMessage(
+		message: string,
+		secret: MaybePromise<SecretLike>,
+	): Promise<Uint8Array> {
 		const secretBytes = await secretToKeyBytes(secret);
 		const secretKeyBuffer = bytesToArrayBuffer(secretBytes);
 
@@ -270,7 +298,7 @@ class MlKemWrapper implements IMlKem {
 
 	async decryptMessage(
 		encryptedMessage: Uint8Array,
-		secret: unknown,
+		secret: MaybePromise<SecretLike>,
 	): Promise<string> {
 		const secretBytes = await secretToKeyBytes(secret);
 		const secretKeyBuffer = bytesToArrayBuffer(secretBytes);

--- a/src/mldsa.ts
+++ b/src/mldsa.ts
@@ -7,52 +7,13 @@ import {
 	withStack,
 	writeBytes,
 } from "./signature-common.js";
-import type { IFnDsa, MlDsaVariant } from "./types.js";
+import type { BytesLike, IFnDsa, MlDsaVariant } from "./types.js";
+import type { MlDsa65Wasm } from "./vendor/mldsa65.js";
 import MlDsa65Module from "./vendor/mldsa65.js";
+import type { MlDsa87Wasm } from "./vendor/mldsa87.js";
 import MlDsa87Module from "./vendor/mldsa87.js";
 
-type MlDsaModule = {
-	_mldsa65_public_key_bytes?: () => number;
-	_mldsa65_private_key_bytes?: () => number;
-	_mldsa65_signature_bytes?: () => number;
-	_mldsa65_seed_bytes?: () => number;
-	_mldsa65_random_bytes?: () => number;
-	_mldsa65_keypair_seeded?: (pk: number, sk: number, seed: number) => number;
-	_mldsa65_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		rnd: number,
-	) => number;
-	_mldsa65_verify_signature?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-	_mldsa87_public_key_bytes?: () => number;
-	_mldsa87_private_key_bytes?: () => number;
-	_mldsa87_signature_bytes?: () => number;
-	_mldsa87_seed_bytes?: () => number;
-	_mldsa87_random_bytes?: () => number;
-	_mldsa87_keypair_seeded?: (pk: number, sk: number, seed: number) => number;
-	_mldsa87_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		rnd: number,
-	) => number;
-	_mldsa87_verify_signature?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-} & import("./signature-common.js").EmscriptenModule;
+type MlDsaModule = MlDsa65Wasm & MlDsa87Wasm;
 
 type MlDsaApi = {
 	getModule: () => Promise<MlDsaModule>;
@@ -202,17 +163,14 @@ class MlDsaWrapper implements IFnDsa {
 		};
 	}
 
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array> {
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array> {
 		return Promise.all([
 			ensureInit(this.variant),
 			Promise.resolve(private_key),
 		]).then(([module, sk]) => {
 			const api = getApi(this.variant);
 			const msg = asBytes(message);
-			const key = asBytes(sk as Uint8Array | ArrayBuffer | string);
+			const key = asBytes(sk);
 			const rnd = crypto.getRandomValues(
 				new Uint8Array(api.randomBytes(module)),
 			);
@@ -231,9 +189,9 @@ class MlDsaWrapper implements IFnDsa {
 	}
 
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean> {
 		return Promise.all([
 			ensureInit(this.variant),
@@ -242,7 +200,7 @@ class MlDsaWrapper implements IFnDsa {
 			const api = getApi(this.variant);
 			const sig = asBytes(signature);
 			const msg = asBytes(message);
-			const key = asBytes(pk as Uint8Array | ArrayBuffer | string);
+			const key = asBytes(pk);
 			return withStack(module, (alloc) => {
 				const sigPtr = writeBytes(module, alloc, sig);
 				const msgPtr = writeBytes(module, alloc, msg);
@@ -255,7 +213,7 @@ class MlDsaWrapper implements IFnDsa {
 		});
 	}
 
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string {
+	buffer_to_string(value: BytesLike): string {
 		if (typeof value === "string") return value;
 		return toHex(asBytes(value));
 	}

--- a/src/signature-common.ts
+++ b/src/signature-common.ts
@@ -1,9 +1,10 @@
+import type { BytesLike } from "./types.js";
+
 export type EmscriptenModule = {
 	HEAPU8: Uint8Array;
 	stackSave(): number;
 	stackAlloc(size: number): number;
 	stackRestore(stack: number): void;
-	[name: string]: unknown;
 };
 
 export function toHex(bytes: Uint8Array): string {
@@ -23,7 +24,7 @@ export function fromHex(hex: string): Uint8Array {
 	return out;
 }
 
-export function asBytes(value: Uint8Array | ArrayBuffer | string): Uint8Array {
+export function asBytes(value: BytesLike): Uint8Array {
 	if (typeof value === "string") return fromHex(value);
 	if (value instanceof Uint8Array) return value;
 	return new Uint8Array(value);

--- a/src/slhdsa.ts
+++ b/src/slhdsa.ts
@@ -4,7 +4,7 @@ import {
 	slh_dsa_sha2_256s,
 } from "@noble/post-quantum/slh-dsa.js";
 import { asBytes, toHex } from "./signature-common.js";
-import type { IFnDsa, KeyPair, SlhDsaVariant } from "./types.js";
+import type { BytesLike, IFnDsa, KeyPair, SlhDsaVariant } from "./types.js";
 
 type SlhDsaImpl = typeof slh_dsa_sha2_128s;
 
@@ -35,37 +35,27 @@ class SlhDsaWrapper implements IFnDsa {
 		};
 	}
 
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array> {
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array> {
 		return Promise.resolve(private_key).then((sk) =>
-			this.impl().sign(
-				asBytes(message as Uint8Array | ArrayBuffer | string),
-				asBytes(sk as Uint8Array | ArrayBuffer | string),
-			),
+			this.impl().sign(asBytes(message), asBytes(sk)),
 		);
 	}
 
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean> {
 		return Promise.all([
 			Promise.resolve(signature),
 			Promise.resolve(message),
 			Promise.resolve(public_key),
 		]).then(([sig, msg, pk]) =>
-			this.impl().verify(
-				asBytes(sig),
-				asBytes(msg),
-				asBytes(pk as Uint8Array | ArrayBuffer | string),
-			),
+			this.impl().verify(asBytes(sig), asBytes(msg), asBytes(pk)),
 		);
 	}
 
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string {
+	buffer_to_string(value: BytesLike): string {
 		if (typeof value === "string") return value;
 		return toHex(asBytes(value));
 	}

--- a/src/sqisign-webgpu.ts
+++ b/src/sqisign-webgpu.ts
@@ -1,3 +1,4 @@
+import { asBytes, toHex } from "./signature-common.js";
 import {
 	loadSqisignLvl1,
 	loadSqisignLvl3,
@@ -10,7 +11,7 @@ import {
 	type SqisignWebGpuSupport,
 	type SqisignWebGpuVariant,
 } from "./sqisign-accel-env.js";
-import type { IFnDsa, KeyPair, SqisignVariant } from "./types.js";
+import type { BytesLike, IFnDsa, KeyPair, SqisignVariant } from "./types.js";
 import { initWebGpuDevice, warmupWebGpu } from "./webgpu/init.js";
 
 export {
@@ -247,25 +248,10 @@ class SqisignWebGpuWrapper implements IFnDsa {
 		};
 	}
 
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array> {
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array> {
 		return Promise.resolve(private_key).then(async (sk) => {
-			const msg = new Uint8Array(
-				typeof message === "string"
-					? new TextEncoder().encode(message)
-					: message instanceof Uint8Array
-						? message
-						: new Uint8Array(message),
-			);
-			const key = new Uint8Array(
-				sk instanceof Uint8Array
-					? sk
-					: sk instanceof ArrayBuffer
-						? new Uint8Array(sk)
-						: new Uint8Array(sk as ArrayBuffer),
-			);
+			const msg = asBytes(message);
+			const key = asBytes(sk);
 			const result = await postToWorker(
 				{
 					id: nextId++,
@@ -284,38 +270,18 @@ class SqisignWebGpuWrapper implements IFnDsa {
 	}
 
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean> {
 		return Promise.all([
 			Promise.resolve(signature),
 			Promise.resolve(message),
 			Promise.resolve(public_key),
 		]).then(async ([sig, msg, pk]) => {
-			const sigBytes = new Uint8Array(
-				typeof sig === "string"
-					? Uint8Array.from(
-							(sig.match(/.{1,2}/g) ?? []).map((b) => Number.parseInt(b, 16)),
-						)
-					: sig instanceof Uint8Array
-						? sig
-						: new Uint8Array(sig),
-			);
-			const msgBytes = new Uint8Array(
-				typeof msg === "string"
-					? new TextEncoder().encode(msg)
-					: msg instanceof Uint8Array
-						? msg
-						: new Uint8Array(msg),
-			);
-			const pkBytes = new Uint8Array(
-				pk instanceof Uint8Array
-					? pk
-					: pk instanceof ArrayBuffer
-						? new Uint8Array(pk)
-						: new Uint8Array(pk as ArrayBuffer),
-			);
+			const sigBytes = asBytes(sig);
+			const msgBytes = asBytes(msg);
+			const pkBytes = asBytes(pk);
 			const result = await postToWorker(
 				{
 					id: nextId++,
@@ -332,10 +298,9 @@ class SqisignWebGpuWrapper implements IFnDsa {
 		});
 	}
 
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string {
+	buffer_to_string(value: BytesLike): string {
 		if (typeof value === "string") return value;
-		const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
-		return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(" ");
+		return toHex(asBytes(value));
 	}
 
 	get label(): string {

--- a/src/sqisign.ts
+++ b/src/sqisign.ts
@@ -7,82 +7,15 @@ import {
 	withStack,
 	writeBytes,
 } from "./signature-common.js";
-import type { IFnDsa, KeyPair, SqisignVariant } from "./types.js";
+import type { BytesLike, IFnDsa, KeyPair, SqisignVariant } from "./types.js";
+import type { SqisignLvl1Wasm } from "./vendor/sqisignlvl1.js";
 import SqisignLvl1Module from "./vendor/sqisignlvl1.js";
+import type { SqisignLvl3Wasm } from "./vendor/sqisignlvl3.js";
 import SqisignLvl3Module from "./vendor/sqisignlvl3.js";
+import type { SqisignLvl5Wasm } from "./vendor/sqisignlvl5.js";
 import SqisignLvl5Module from "./vendor/sqisignlvl5.js";
 
-type SqisignModule = {
-	_sqisign_lvl1_public_key_bytes?: () => number;
-	_sqisign_lvl1_private_key_bytes?: () => number;
-	_sqisign_lvl1_signature_bytes?: () => number;
-	_sqisign_lvl1_seed_bytes?: () => number;
-	_sqisign_lvl1_keypair_seeded?: (
-		pk: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl1_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl1_verify?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-	_sqisign_lvl3_public_key_bytes?: () => number;
-	_sqisign_lvl3_private_key_bytes?: () => number;
-	_sqisign_lvl3_signature_bytes?: () => number;
-	_sqisign_lvl3_seed_bytes?: () => number;
-	_sqisign_lvl3_keypair_seeded?: (
-		pk: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl3_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl3_verify?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-	_sqisign_lvl5_public_key_bytes?: () => number;
-	_sqisign_lvl5_private_key_bytes?: () => number;
-	_sqisign_lvl5_signature_bytes?: () => number;
-	_sqisign_lvl5_seed_bytes?: () => number;
-	_sqisign_lvl5_keypair_seeded?: (
-		pk: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl5_sign_seeded?: (
-		sig: number,
-		msg: number,
-		msgLen: number,
-		sk: number,
-		seed: number,
-	) => number;
-	_sqisign_lvl5_verify?: (
-		sig: number,
-		sigLen: number,
-		msg: number,
-		msgLen: number,
-		pk: number,
-	) => number;
-} & import("./signature-common.js").EmscriptenModule;
+type SqisignModule = SqisignLvl1Wasm & SqisignLvl3Wasm & SqisignLvl5Wasm;
 
 type SqisignApi = {
 	getModule: () => Promise<SqisignModule>;
@@ -275,17 +208,14 @@ class SqisignWrapper implements IFnDsa {
 		};
 	}
 
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array> {
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array> {
 		return Promise.all([
 			ensureInit(this.variant),
 			Promise.resolve(private_key),
 		]).then(([module, sk]) => {
 			const api = getApi(this.variant);
-			const msg = asBytes(message as Uint8Array | ArrayBuffer | string);
-			const key = asBytes(sk as Uint8Array | ArrayBuffer | string);
+			const msg = asBytes(message);
+			const key = asBytes(sk);
 			const seed = crypto.getRandomValues(
 				new Uint8Array(api.seedBytes(module)),
 			);
@@ -306,9 +236,9 @@ class SqisignWrapper implements IFnDsa {
 	}
 
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean> {
 		return Promise.all([
 			ensureInit(this.variant),
@@ -317,7 +247,7 @@ class SqisignWrapper implements IFnDsa {
 			const api = getApi(this.variant);
 			const sig = asBytes(signature);
 			const msg = asBytes(message);
-			const key = asBytes(pk as Uint8Array | ArrayBuffer | string);
+			const key = asBytes(pk);
 			return withStack(module, (alloc) => {
 				const sigPtr = writeBytes(module, alloc, sig);
 				const msgPtr = writeBytes(module, alloc, msg);
@@ -330,7 +260,7 @@ class SqisignWrapper implements IFnDsa {
 		});
 	}
 
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string {
+	buffer_to_string(value: BytesLike): string {
 		if (typeof value === "string") return value;
 		return toHex(asBytes(value));
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,49 @@
 export type MaybePromise<T> = T | Promise<T>;
 
+/** Hex string, ArrayBuffer, or raw bytes — common input for signature APIs. */
+export type BytesLike = Uint8Array | ArrayBuffer | string;
+
+/**
+ * Key material returned by signature schemes (FN-DSA, ML-DSA, SLH-DSA, SQIsign).
+ * Prefer awaiting `get(...)` so callers always hold concrete `Uint8Array`s.
+ */
 export interface KeyPair {
-	// `mlkem-wasm` is async under the hood; we expose that via Promise values.
-	get(key: "public_key" | "private_key"): MaybePromise<any>;
+	get(key: "public_key" | "private_key"): MaybePromise<Uint8Array>;
+}
+
+/**
+ * ML-KEM keys are Web Crypto `CryptoKey` handles (raw export via `buffer_to_string`).
+ */
+export interface MlKemKeyPair {
+	get(key: "public_key" | "private_key"): MaybePromise<CryptoKey>;
 }
 
 export interface EncryptResult {
 	// `cyphertext` is intentionally spelled this way to match the existing README/API.
-	get(key: "cyphertext" | "secret"): MaybePromise<any>;
+	get(key: "cyphertext" | "secret"): MaybePromise<ArrayBuffer>;
 }
 
+/** Shared secret material for AES-GCM helpers (KEM secret or hex). */
+export type SecretLike = BytesLike | ArrayBufferView;
+
 export interface IMlKem {
-	keypair(): KeyPair;
-	encrypt(public_key: any): EncryptResult;
-	decrypt(cyphertext: any, private_key: any): Promise<any>;
-	buffer_to_string(buffer: any): MaybePromise<string>;
-	encryptMessage(message: string, secret: any): Promise<Uint8Array>;
-	decryptMessage(encryptedMessage: Uint8Array, secret: any): Promise<string>;
+	keypair(): MlKemKeyPair;
+	encrypt(public_key: MaybePromise<CryptoKey>): EncryptResult;
+	decrypt(
+		cyphertext: MaybePromise<BufferSource>,
+		private_key: MaybePromise<CryptoKey>,
+	): Promise<ArrayBuffer>;
+	buffer_to_string(
+		buffer: MaybePromise<CryptoKey | BufferSource | string>,
+	): MaybePromise<string>;
+	encryptMessage(
+		message: string,
+		secret: MaybePromise<SecretLike>,
+	): Promise<Uint8Array>;
+	decryptMessage(
+		encryptedMessage: Uint8Array,
+		secret: MaybePromise<SecretLike>,
+	): Promise<string>;
 	delete(): void;
 }
 
@@ -29,16 +56,13 @@ export type SqisignVariant = "lvl1" | "lvl3" | "lvl5";
 
 export interface IFnDsa {
 	keypair(): KeyPair;
-	sign(
-		message: Uint8Array | ArrayBuffer | string,
-		private_key: unknown,
-	): Promise<Uint8Array>;
+	sign(message: BytesLike, private_key: BytesLike): Promise<Uint8Array>;
 	verify(
-		signature: Uint8Array | ArrayBuffer | string,
-		message: Uint8Array | ArrayBuffer | string,
-		public_key: unknown,
+		signature: BytesLike,
+		message: BytesLike,
+		public_key: BytesLike,
 	): Promise<boolean>;
-	buffer_to_string(value: Uint8Array | ArrayBuffer | string): string;
+	buffer_to_string(value: BytesLike): string;
 }
 
 export type IMlDsa = IFnDsa;

--- a/src/vendor/emscripten-runtime.d.ts
+++ b/src/vendor/emscripten-runtime.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared Emscripten runtime surface used by signature WASM modules.
+ * Concrete modules add their `_…` exports in per-file `.d.ts` stubs.
+ */
+export type EmscriptenRuntime = {
+	HEAPU8: Uint8Array;
+	getValue(ptr: number, type: string): number;
+	setValue(ptr: number, value: number, type: string): void;
+	stackSave(): number;
+	stackAlloc(size: number): number;
+	stackRestore(stack: number): void;
+};
+
+export type EmscriptenModuleFactory<T extends EmscriptenRuntime> = (
+	moduleArg?: Partial<EmscriptenRuntime>,
+) => Promise<T>;

--- a/src/vendor/falcon1024.d.ts
+++ b/src/vendor/falcon1024.d.ts
@@ -1,2 +1,29 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type Falcon1024Wasm = EmscriptenRuntime & {
+	_falcon1024_public_key_bytes(): number;
+	_falcon1024_private_key_bytes(): number;
+	_falcon1024_signature_bytes(): number;
+	_falcon1024_seed_bytes(): number;
+	_falcon1024_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_falcon1024_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		seed: number,
+	): number;
+	_falcon1024_verify(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<Falcon1024Wasm>;
 export default init;

--- a/src/vendor/falcon512.d.ts
+++ b/src/vendor/falcon512.d.ts
@@ -1,2 +1,29 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type Falcon512Wasm = EmscriptenRuntime & {
+	_falcon512_public_key_bytes(): number;
+	_falcon512_private_key_bytes(): number;
+	_falcon512_signature_bytes(): number;
+	_falcon512_seed_bytes(): number;
+	_falcon512_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_falcon512_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		seed: number,
+	): number;
+	_falcon512_verify(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<Falcon512Wasm>;
 export default init;

--- a/src/vendor/mldsa65.d.ts
+++ b/src/vendor/mldsa65.d.ts
@@ -1,2 +1,30 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type MlDsa65Wasm = EmscriptenRuntime & {
+	_mldsa65_public_key_bytes(): number;
+	_mldsa65_private_key_bytes(): number;
+	_mldsa65_signature_bytes(): number;
+	_mldsa65_seed_bytes(): number;
+	_mldsa65_random_bytes(): number;
+	_mldsa65_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_mldsa65_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		rnd: number,
+	): number;
+	_mldsa65_verify_signature(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<MlDsa65Wasm>;
 export default init;

--- a/src/vendor/mldsa87.d.ts
+++ b/src/vendor/mldsa87.d.ts
@@ -1,2 +1,30 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type MlDsa87Wasm = EmscriptenRuntime & {
+	_mldsa87_public_key_bytes(): number;
+	_mldsa87_private_key_bytes(): number;
+	_mldsa87_signature_bytes(): number;
+	_mldsa87_seed_bytes(): number;
+	_mldsa87_random_bytes(): number;
+	_mldsa87_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_mldsa87_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		rnd: number,
+	): number;
+	_mldsa87_verify_signature(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<MlDsa87Wasm>;
 export default init;

--- a/src/vendor/sqisignlvl1.d.ts
+++ b/src/vendor/sqisignlvl1.d.ts
@@ -1,2 +1,29 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type SqisignLvl1Wasm = EmscriptenRuntime & {
+	_sqisign_lvl1_public_key_bytes(): number;
+	_sqisign_lvl1_private_key_bytes(): number;
+	_sqisign_lvl1_signature_bytes(): number;
+	_sqisign_lvl1_seed_bytes(): number;
+	_sqisign_lvl1_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_sqisign_lvl1_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		seed: number,
+	): number;
+	_sqisign_lvl1_verify(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<SqisignLvl1Wasm>;
 export default init;

--- a/src/vendor/sqisignlvl3.d.ts
+++ b/src/vendor/sqisignlvl3.d.ts
@@ -1,2 +1,29 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type SqisignLvl3Wasm = EmscriptenRuntime & {
+	_sqisign_lvl3_public_key_bytes(): number;
+	_sqisign_lvl3_private_key_bytes(): number;
+	_sqisign_lvl3_signature_bytes(): number;
+	_sqisign_lvl3_seed_bytes(): number;
+	_sqisign_lvl3_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_sqisign_lvl3_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		seed: number,
+	): number;
+	_sqisign_lvl3_verify(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<SqisignLvl3Wasm>;
 export default init;

--- a/src/vendor/sqisignlvl5.d.ts
+++ b/src/vendor/sqisignlvl5.d.ts
@@ -1,2 +1,29 @@
-declare const init: (moduleArg?: Record<string, unknown>) => Promise<any>;
+import type {
+	EmscriptenModuleFactory,
+	EmscriptenRuntime,
+} from "./emscripten-runtime.js";
+
+export type SqisignLvl5Wasm = EmscriptenRuntime & {
+	_sqisign_lvl5_public_key_bytes(): number;
+	_sqisign_lvl5_private_key_bytes(): number;
+	_sqisign_lvl5_signature_bytes(): number;
+	_sqisign_lvl5_seed_bytes(): number;
+	_sqisign_lvl5_keypair_seeded(pk: number, sk: number, seed: number): number;
+	_sqisign_lvl5_sign_seeded(
+		sig: number,
+		msg: number,
+		msgLen: number,
+		sk: number,
+		seed: number,
+	): number;
+	_sqisign_lvl5_verify(
+		sig: number,
+		sigLen: number,
+		msg: number,
+		msgLen: number,
+		pk: number,
+	): number;
+};
+
+declare const init: EmscriptenModuleFactory<SqisignLvl5Wasm>;
 export default init;

--- a/website/docs/guides/security.md
+++ b/website/docs/guides/security.md
@@ -41,6 +41,14 @@ The algorithm spectacularly broken in 2022 was **SIDH** (Castryck–Decru / auxi
 
 This implementation includes patches aimed at side-channel resistance. Background reading: [KyberSlash / related work](https://kannwischer.eu/papers/2024_kyberslash_preprint20240628.pdf).
 
+## TypeScript types (auditability)
+
+The public API is typed under `strict` TypeScript (`BytesLike`, `Uint8Array` / `CryptoKey` key material, typed WASM module stubs). That helps humans and automated review see how keys and buffers move through the wrappers.
+
+**What types help:** misuse resistance, clearer review of crypto boundaries, fewer opaque `any` escape hatches.
+
+**What types do not prove:** they do not control V8 optimizations and do not by themselves establish constant-time behavior. Timing and related claims still need C/WASM review (and separate test-vector work).
+
 ## Independent checks
 
 ```bash


### PR DESCRIPTION
- Introduced `BytesLike` type to standardize input across signature APIs.
- Updated function signatures in various modules (e.g., `FnDsa`, `MlKem`, `SlhDsa`, `Sqisign`) to use `BytesLike` for message and key parameters.
- Enhanced type definitions for key material and encryption results to improve type safety and auditability.
- Updated `biome.json` to enforce stricter linter rules regarding explicit `any` usage.